### PR TITLE
Remove the setup function as it is no longer needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,21 +4,6 @@ const channels = {}
 const providers = {}
 
 module.exports = {
-  setup: (allOptions, ) => {
-    // set up providers
-  
-    Object.keys(channelMap).forEach(key => {
-      const providerKey = channelMap[key]
-      const providerOptions = allOptions[providerKey]
-
-      if (!provider) {
-        strapi.logger.error(`Unknown email provider: ${providerKey}. Using console instead.`)
-      }
-
-      channels[key] = providerKey || allOptions.console
-    })
-  },
-
   init: (providerOptions = {}, settings = {}) => {
   
     // Init all providers.


### PR DESCRIPTION
Fixes #1 

# What & Why

- Remove the `setup` function.
  - This was from an earlier implementation, but is not used anymore.